### PR TITLE
chore: replace see-more link with animated information modal with carousel and Cloudinary images

### DIFF
--- a/src/app/mapper/snoop-information.json
+++ b/src/app/mapper/snoop-information.json
@@ -120,7 +120,8 @@
         "https://res.cloudinary.com/dnfbvjyyw/image/upload/v1780633006/IMG_20220905_091901_952_lzbfbq.jpg",
         "https://res.cloudinary.com/dnfbvjyyw/image/upload/v1780632849/IMG_20220712_085112534_vtg9hb.jpg",
         "https://res.cloudinary.com/dnfbvjyyw/image/upload/v1780633110/IMG_20220728_004105058_mb6jga.jpg",
-        "https://res.cloudinary.com/dnfbvjyyw/image/upload/v1780633490/IMG_20221003_174015341_evkaqd.jpg"
+        "https://res.cloudinary.com/dnfbvjyyw/image/upload/v1780633490/IMG_20221003_174015341_evkaqd.jpg",
+        "https://res.cloudinary.com/dnfbvjyyw/image/upload/v1780632970/IMG_20220729_160052222_wdjbra.jpg"
       ],
       "contributions": []
     },

--- a/src/app/mapper/snoop-information.json
+++ b/src/app/mapper/snoop-information.json
@@ -31,9 +31,9 @@
       ],
       "images": [
         "https://res.cloudinary.com/dnfbvjyyw/image/upload/v1780633019/IMG_20251212_162654488_HDR_nx13wm.jpg",
+        "https://res.cloudinary.com/dnfbvjyyw/image/upload/v1780636926/cake-1_ffwqap.jpg",
         "https://res.cloudinary.com/dnfbvjyyw/image/upload/v1780633093/IMG_20260130_180817470_hyzply.jpg",
-        "https://res.cloudinary.com/dnfbvjyyw/image/upload/v1780634832/img_7417_y2iw9y.jpg",
-        "https://res.cloudinary.com/dnfbvjyyw/image/upload/v1780636926/cake-1_ffwqap.jpg"
+        "https://res.cloudinary.com/dnfbvjyyw/image/upload/v1780634832/img_7417_y2iw9y.jpg"
       ],
       "contributions": []
     },

--- a/src/app/mapper/snoop-information.json
+++ b/src/app/mapper/snoop-information.json
@@ -61,7 +61,10 @@
         "PostgreSQL",
         "GitHub Actions"
       ],
-      "images": [],
+      "images": [
+        "https://res.cloudinary.com/dnfbvjyyw/image/upload/v1780633178/IMG_20251017_173041602_jc5tio.jpg",
+        "https://res.cloudinary.com/dnfbvjyyw/image/upload/v1780633186/IMG_20250815_082442315_e6jrcm.jpg"
+      ],
       "contributions": []
     },
     {

--- a/src/app/mapper/snoop-information.json
+++ b/src/app/mapper/snoop-information.json
@@ -32,8 +32,8 @@
       "images": [
         "https://res.cloudinary.com/dnfbvjyyw/image/upload/v1780633019/IMG_20251212_162654488_HDR_nx13wm.jpg",
         "https://res.cloudinary.com/dnfbvjyyw/image/upload/v1780633093/IMG_20260130_180817470_hyzply.jpg",
-        "https://res.cloudinary.com/dnfbvjyyw/image/upload/v1780633132/IMG_20260311_212102540_d2eyz0.jpg",
-        "https://res.cloudinary.com/dnfbvjyyw/image/upload/v1780634832/img_7417_y2iw9y.jpg"
+        "https://res.cloudinary.com/dnfbvjyyw/image/upload/v1780634832/img_7417_y2iw9y.jpg",
+        "https://res.cloudinary.com/dnfbvjyyw/image/upload/v1780636926/cake-1_ffwqap.jpg"
       ],
       "contributions": []
     },
@@ -126,7 +126,6 @@
       ],
       "images": [
         "https://res.cloudinary.com/dnfbvjyyw/image/upload/v1780633006/IMG_20220905_091901_952_lzbfbq.jpg",
-        "https://res.cloudinary.com/dnfbvjyyw/image/upload/v1780632849/IMG_20220712_085112534_vtg9hb.jpg",
         "https://res.cloudinary.com/dnfbvjyyw/image/upload/v1780633110/IMG_20220728_004105058_mb6jga.jpg",
         "https://res.cloudinary.com/dnfbvjyyw/image/upload/v1780633490/IMG_20221003_174015341_evkaqd.jpg",
         "https://res.cloudinary.com/dnfbvjyyw/image/upload/v1780632970/IMG_20220729_160052222_wdjbra.jpg"

--- a/src/app/mapper/snoop-information.json
+++ b/src/app/mapper/snoop-information.json
@@ -32,7 +32,8 @@
       "images": [
         "https://res.cloudinary.com/dnfbvjyyw/image/upload/v1780633019/IMG_20251212_162654488_HDR_nx13wm.jpg",
         "https://res.cloudinary.com/dnfbvjyyw/image/upload/v1780633093/IMG_20260130_180817470_hyzply.jpg",
-        "https://res.cloudinary.com/dnfbvjyyw/image/upload/v1780633132/IMG_20260311_212102540_d2eyz0.jpg"
+        "https://res.cloudinary.com/dnfbvjyyw/image/upload/v1780633132/IMG_20260311_212102540_d2eyz0.jpg",
+        "https://res.cloudinary.com/dnfbvjyyw/image/upload/v1780634832/img_7417_y2iw9y.jpg"
       ],
       "contributions": []
     },

--- a/src/app/mapper/snoop-information.json
+++ b/src/app/mapper/snoop-information.json
@@ -29,7 +29,11 @@
         "Redis",
         "GitHub Actions"
       ],
-      "images": [],
+      "images": [
+        "https://res.cloudinary.com/dnfbvjyyw/image/upload/v1780633019/IMG_20251212_162654488_HDR_nx13wm.jpg",
+        "https://res.cloudinary.com/dnfbvjyyw/image/upload/v1780633093/IMG_20260130_180817470_hyzply.jpg",
+        "https://res.cloudinary.com/dnfbvjyyw/image/upload/v1780633132/IMG_20260311_212102540_d2eyz0.jpg"
+      ],
       "contributions": []
     },
     {
@@ -112,7 +116,9 @@
         "PostgreSQL",
         "Gitlab CI/CD"
       ],
-      "images": [],
+      "images": [
+        "https://photos.google.com/share/AF1QipOe6ENyRNQzu6ObCLyzdToAjfNfWfdMqF99MjA8LzeegFTnnUDF7RRHYfcClV-rtw/photo/AF1QipMOYBT-aAudSvlU1tt0sNgx8nfIto0dMbgXcHPn"
+      ],
       "contributions": []
     },
     {

--- a/src/app/mapper/snoop-information.json
+++ b/src/app/mapper/snoop-information.json
@@ -88,7 +88,11 @@
         "Docker",
         "Google Cloud Platform"
       ],
-      "images": [],
+      "images": [
+        "https://res.cloudinary.com/dnfbvjyyw/image/upload/v1780633036/IMG_20240826_184603_473_epodcr.jpg",
+        "https://res.cloudinary.com/dnfbvjyyw/image/upload/v1780633061/IMG_20240322_181713897_qyzwnc.jpg",
+        "https://res.cloudinary.com/dnfbvjyyw/image/upload/v1780633431/IMG_20240611_183526412_hn3xmx.jpg"
+      ],
       "contributions": []
     },
     {

--- a/src/app/mapper/snoop-information.json
+++ b/src/app/mapper/snoop-information.json
@@ -117,7 +117,10 @@
         "Gitlab CI/CD"
       ],
       "images": [
-        "https://photos.google.com/share/AF1QipOe6ENyRNQzu6ObCLyzdToAjfNfWfdMqF99MjA8LzeegFTnnUDF7RRHYfcClV-rtw/photo/AF1QipMOYBT-aAudSvlU1tt0sNgx8nfIto0dMbgXcHPn"
+        "https://res.cloudinary.com/dnfbvjyyw/image/upload/v1780633006/IMG_20220905_091901_952_lzbfbq.jpg",
+        "https://res.cloudinary.com/dnfbvjyyw/image/upload/v1780632849/IMG_20220712_085112534_vtg9hb.jpg",
+        "https://res.cloudinary.com/dnfbvjyyw/image/upload/v1780633110/IMG_20220728_004105058_mb6jga.jpg",
+        "https://res.cloudinary.com/dnfbvjyyw/image/upload/v1780633490/IMG_20221003_174015341_evkaqd.jpg"
       ],
       "contributions": []
     },

--- a/src/app/mapper/snoop-information.json
+++ b/src/app/mapper/snoop-information.json
@@ -32,7 +32,8 @@
       "images": [
         "https://res.cloudinary.com/dnfbvjyyw/image/upload/v1780633019/IMG_20251212_162654488_HDR_nx13wm.jpg",
         "https://res.cloudinary.com/dnfbvjyyw/image/upload/v1780633093/IMG_20260130_180817470_hyzply.jpg",
-        "https://res.cloudinary.com/dnfbvjyyw/image/upload/v1780633132/IMG_20260311_212102540_d2eyz0.jpg"
+        "https://res.cloudinary.com/dnfbvjyyw/image/upload/v1780633132/IMG_20260311_212102540_d2eyz0.jpg",
+        "https://res.cloudinary.com/dnfbvjyyw/image/upload/v1780633078/IMG_20251212_131920849_BURST000_COVER_tiovee.jpg"
       ],
       "contributions": []
     },

--- a/src/app/mapper/snoop-information.json
+++ b/src/app/mapper/snoop-information.json
@@ -32,8 +32,7 @@
       "images": [
         "https://res.cloudinary.com/dnfbvjyyw/image/upload/v1780633019/IMG_20251212_162654488_HDR_nx13wm.jpg",
         "https://res.cloudinary.com/dnfbvjyyw/image/upload/v1780633093/IMG_20260130_180817470_hyzply.jpg",
-        "https://res.cloudinary.com/dnfbvjyyw/image/upload/v1780633132/IMG_20260311_212102540_d2eyz0.jpg",
-        "https://res.cloudinary.com/dnfbvjyyw/image/upload/v1780633078/IMG_20251212_131920849_BURST000_COVER_tiovee.jpg"
+        "https://res.cloudinary.com/dnfbvjyyw/image/upload/v1780633132/IMG_20260311_212102540_d2eyz0.jpg"
       ],
       "contributions": []
     },

--- a/src/components/patterns/modal-pattern.tsx
+++ b/src/components/patterns/modal-pattern.tsx
@@ -117,7 +117,7 @@ export function AnimatedModal({ slug }: { slug?: string }) {
                 </Carousel>
               ) : (
                 <p className="text-center text-sm text-neutral-400 dark:text-neutral-500">
-                  No related{' '}
+                  No public{' '}
                   {detail.type === 'work' ? 'contributions' : 'projects'} to
                   display.
                 </p>

--- a/src/components/patterns/modal-pattern.tsx
+++ b/src/components/patterns/modal-pattern.tsx
@@ -192,15 +192,21 @@ function LinksSection({ links }: { links: CardDetail['links'] }) {
 
 function ImagesGrid({ images }: { images: string[] }) {
   const [expandedIdx, setExpandedIdx] = useState<number | null>(null);
+  const [loaded, setLoaded] = useState<Record<number, boolean>>({});
 
   const toggleExpand = (idx: number) => {
     setExpandedIdx(expandedIdx === idx ? null : idx);
+  };
+
+  const handleLoad = (idx: number) => {
+    setLoaded(prev => ({ ...prev, [idx]: true }));
   };
 
   return (
     <div className="flex justify-center items-center flex-wrap gap-2">
       {images.map((src, idx) => {
         const isExpanded = expandedIdx === idx;
+        const optimizedSrc = src.replace('/upload/', '/upload/f_auto,q_auto/');
         return (
           <div
             key={idx}
@@ -208,16 +214,20 @@ function ImagesGrid({ images }: { images: string[] }) {
             className={`
               rounded-lg overflow-hidden shrink-0 border border-neutral-200
               dark:border-neutral-700 cursor-pointer transition-all duration-300
-              hover:scale-110 hover:z-10
-              ${isExpanded ? 'scale-110 z-10' : ''}
+              hover:scale-110 hover:z-10 relative
+              ${isExpanded ? 'scale-110 z-10 h-40 w-40 md:h-48 md:w-48' : 'h-20 w-20 md:h-28 md:w-28'}
             `}
           >
+            {!loaded[idx] && (
+              <div className="absolute inset-0 bg-neutral-200 dark:bg-neutral-700 animate-pulse rounded-lg" />
+            )}
             <img
-              src={src}
+              src={optimizedSrc}
               alt=""
+              onLoad={() => handleLoad(idx)}
               className={`
-                object-cover transition-all duration-300
-                ${isExpanded ? 'h-40 w-40 md:h-48 md:w-48' : 'h-20 w-20 md:h-28 md:w-28'}
+                object-cover w-full h-full transition-opacity duration-300
+                ${loaded[idx] ? 'opacity-100' : 'opacity-0'}
               `}
             />
           </div>


### PR DESCRIPTION
## Summary

- **Modal**: replaces the old LinkedIn "See more" link on experience/education cards with a rich animated modal containing project details
- **Carousel**: infinite auto-scroll carousel (Embla) for contributions/projects in place of `detailed_description`
- **Images**: Cloudinary-hosted images with `f_auto,q_auto` optimization and skeleton loading placeholders
- **Fallbacks**: graceful empty-state messages and fallback SVG when images or projects are missing
- **New entry**: Azion card added to both timeline and detail data
- **Data cleanup**: all entries now use `slug` consistently; `detailed_description`, `see_more_link`, and `FallbackLinks` component removed
- **Fix**: `cards_timeline` barrel export corrected for Vercel build

## Files changed

- `src/components/patterns/modal-pattern.tsx` — carousel, image skeleton, fallbacks, type narrowing
- `src/components/ui/modal.tsx` — reusable animated modal with portal
- `src/components/patterns/card-experience-pattern.tsx` — wired modal via slug
- `src/app/mapper/snoop-information.json` — all detail data with Cloudinary images
- `src/app/mapper/cards-timeline.json` — Azion entry, English descriptions
- `src/app/mapper/index.ts` — fixed barrel export for `cards_timeline`
- `src/app/pages/about/page.tsx` — uses barrel import
- `public/image_fallback_two.svg` — fallback image asset